### PR TITLE
Fix: resolve TypeError when adding projects

### DIFF
--- a/src/components/Analytics/ProjectStats.tsx
+++ b/src/components/Analytics/ProjectStats.tsx
@@ -228,7 +228,7 @@ export const ProjectStats: React.FC<ProjectStatsProps> = ({ projects, className 
                 {getStatusIcon(status as ProjectStatus)}
               </div>
               <p className="text-sm font-medium text-gray-900">{count}</p>
-              <p className="text-xs text-gray-500 capitalize">{status.replace('-', ' ')}</p>
+              <p className="text-xs text-gray-500 capitalize">{status?.replace('-', ' ') || 'Unknown'}</p>
             </div>
           ))}
         </div>

--- a/src/components/Management/ProjectList.tsx
+++ b/src/components/Management/ProjectList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Search, Edit2, Trash2, Calendar, User, AlertCircle, Clock, Filter, Activity, Pause, CheckCircle, XCircle } from 'lucide-react';
+import { Search, Edit2, Trash2, Calendar, User, AlertCircle, Filter, Activity, Pause, CheckCircle, XCircle } from 'lucide-react';
 import { Project, Resource, ProjectStatus } from '../../types';
 import { PRIORITY_COLORS } from '../../constants/colors';
 
@@ -149,7 +149,7 @@ export const ProjectList: React.FC<ProjectListProps> = ({
     return (
       <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${config.bg} ${config.text}`}>
         <Icon size={12} className="mr-1" />
-        {status.replace('-', ' ')}
+        {status?.replace('-', ' ') || 'Unknown'}
       </span>
     );
   };

--- a/src/components/Modals/ProjectModal.tsx
+++ b/src/components/Modals/ProjectModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Project, Resource } from '../../types';
+import { Project, Resource, ProjectStatus } from '../../types';
 import { X, Calendar, Trash2 } from 'lucide-react';
 import { formatDate } from '../../utils/dateUtils';
 import { MODAL_LEVELS } from '../../constants/zIndex';
@@ -32,6 +32,7 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
   const [workDaysNeeded, setWorkDaysNeeded] = useState('');
   const [resourceId, setResourceId] = useState('');
   const [priority, setPriority] = useState<'high' | 'medium' | 'low'>('medium');
+  const [status, setStatus] = useState<ProjectStatus>('planning');
   const [showRemoveWork, setShowRemoveWork] = useState(false);
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
 
@@ -44,6 +45,7 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
       setWorkDaysNeeded(project.workDaysNeeded?.toString() || '');
       setResourceId(project.resourceId);
       setPriority(project.priority);
+      setStatus(project.status);
     } else {
       setTitle('');
       setStartDate(formatDate(new Date()));
@@ -52,6 +54,7 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
       setWorkDaysNeeded('');
       setResourceId(resources[0]?.id || '');
       setPriority('medium');
+      setStatus('planning');
     }
     setShowRemoveWork(false);
     setSelectedDates([]);
@@ -82,6 +85,8 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
         workDaysNeeded: workDays,
         resourceId,
         priority,
+        status,
+        progress: 0,
       };
       
       if (project) {
@@ -257,6 +262,25 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
               <option value="high">High</option>
               <option value="medium">Medium</option>
               <option value="low">Low</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Status
+            </label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as ProjectStatus)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="planning">Planning</option>
+              <option value="active">Active</option>
+              <option value="on-hold">On Hold</option>
+              <option value="completed">Completed</option>
+              <option value="cancelled">Cancelled</option>
+              <option value="overdue">Overdue</option>
+              <option value="at-risk">At Risk</option>
             </select>
           </div>
 


### PR DESCRIPTION
Fixes #2

This PR resolves the TypeError that occurred when trying to add a project.

## Root Cause
The issue was caused by:
1. Missing defensive programming guards for `status.replace()` calls
2. Missing status field in ProjectModal component during project creation

## Fixes
- Added defensive guards for status string operations
- Added missing status field to ProjectModal with proper UI and state management
- Ensured all required fields are included when creating projects
- Cleanup of unused imports

## Testing
- Build passes successfully
- No TypeScript compilation errors
- Defensive guards handle edge cases gracefully

Generated with [Claude Code](https://claude.ai/code)